### PR TITLE
ci: run all tests on stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,12 +66,7 @@ jobs:
         with:
           version: ${{ matrix.toolchain }}
       - run: forge --version
-      - run: |
-          if [ "${{ matrix.toolchain }}" = "stable" ]; then
-            forge test -vvv --no-match-path "test/Config.t.sol"
-          else
-            forge test -vvv
-          fi
+      - run: forge test -vvv
 
   fmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Run the complete forge test suite unconditionally in the CI workflow instead of skipping specific tests on stable.